### PR TITLE
Remove acid.nvim not found message

### DIFF
--- a/rplugin/python3/deoplete/sources/acid.py
+++ b/rplugin/python3/deoplete/sources/acid.py
@@ -65,7 +65,7 @@ class Source(Base):
         if loaded:
             self.acid_sessions = SessionHandler()
         else:
-            self.vim.command('echomsg "Acid.nvim not found. Please install it."')
+            self.debug('echomsg "Acid.nvim not found. Please install it."')
         self.sessions = {}
 
     def get_wc(self, url):

--- a/rplugin/python3/deoplete/sources/acid.py
+++ b/rplugin/python3/deoplete/sources/acid.py
@@ -65,7 +65,7 @@ class Source(Base):
         if loaded:
             self.acid_sessions = SessionHandler()
         else:
-            self.vim.call('echom "Acid.nvim not found. Please install it."')
+            self.vim.command('echomsg "Acid.nvim not found. Please install it."')
         self.sessions = {}
 
     def get_wc(self, url):


### PR DESCRIPTION
Current echomsg call is broken (`vim.call` instead of `vim.command`) but even if the was correct, I don't want to see the message each time I open Vim.