### PR TITLE
Allow ns to be configured in the buffer

### DIFF
--- a/pythonx/async_clj_omni/acid.py
+++ b/pythonx/async_clj_omni/acid.py
@@ -1,7 +1,7 @@
 import threading
 from async_clj_omni.cider import cider_gather  # NOQA
 try:
-    from acid.nvim import localhost, path_to_ns
+    from acid.nvim import localhost, get_acid_ns
     from acid.session import SessionHandler, send
     loaded = True
 except:
@@ -65,7 +65,7 @@ class AcidManager:
         url = "nrepl://{}:{}".format(*address)
         wc = self.get_wc(url)
         session = self.get_session(url, wc)
-        ns = path_to_ns(self._vim)
+        ns = get_acid_ns(self._vim)
 
         def global_watch(cmsg, cwc, ckey):
             self._logger.debug("Received message for {}".format(url))


### PR DESCRIPTION
Acid allows buffers to configure their namespace via the `acid_ns_strategy`
variable. Changing how we get the namespace allows us to preserve this setting.