### PR TITLE
ncm source: $ is no longer needed in cm_refresh_patterns

### DIFF
--- a/pythonx/cm_sources/acid.py
+++ b/pythonx/cm_sources/acid.py
@@ -5,7 +5,7 @@ register_source(name='acid',
                 abbreviation='acid',
                 scopes=['clojure'],
                 word_pattern=r'[\w!$%&*+/:<=>?@\^_~\-\.#]+',
-                cm_refresh_patterns=[r'/$'],
+                cm_refresh_patterns=[r'/'],
                 priority=9)
 
 import os

--- a/pythonx/cm_sources/fireplace.py
+++ b/pythonx/cm_sources/fireplace.py
@@ -5,7 +5,7 @@ register_source(name='fireplace',
                 abbreviation='🔥',
                 scopes=['clojure'],
                 word_pattern=r'[\w!$%&*+/:<=>?@\^_~\-\.#]+',
-                cm_refresh_patterns=[r'/$'],
+                cm_refresh_patterns=[r'/'],
                 priority=9)
 
 import sys


### PR DESCRIPTION
Hi, I'm trying to fix https://github.com/roxma/nvim-completion-manager/issues/100, due to a breaking chage I made weeks ago.

This PR will avoid side effect after I fix that issue.