### PR TITLE
Handle BrokenPipeError

### DIFF
--- a/pythonx/async_clj_omni/cider.py
+++ b/pythonx/async_clj_omni/cider.py
@@ -29,8 +29,10 @@ def candidate(val):
         "menu": " ".join(arglists) if arglists else ""
     }
 
+def rethrow(e):
+    raise e
 
-def cider_gather(logger, nrepl, keyword, session, ns):
+def cider_gather(logger, nrepl, keyword, session, ns, on_error=rethrow):
     # Should be unique for EVERY message
     msgid = uuid.uuid4().hex
 
@@ -50,15 +52,18 @@ def cider_gather(logger, nrepl, keyword, session, ns):
 
     logger.debug("cider_gather watching msgid")
 
-    # TODO: context for context aware completions
-    nrepl.send({
-        "id": msgid,
-        "op": "complete",
-        "session": session,
-        "symbol": keyword,
-        "extra-metadata": ["arglists", "doc"],
-        "ns": ns
-    })
+    try:
+        # TODO: context for context aware completions
+        nrepl.send({
+            "id": msgid,
+            "op": "complete",
+            "session": session,
+            "symbol": keyword,
+            "extra-metadata": ["arglists", "doc"],
+            "ns": ns
+        })
+    except BrokenPipeError as e:
+        on_error(e)
 
     completion_event.wait(0.5)
 

--- a/pythonx/async_clj_omni/fireplace.py
+++ b/pythonx/async_clj_omni/fireplace.py
@@ -45,6 +45,13 @@ class ConnManager:
 
         return self.__conns.get(conn_string)
 
+    def remove_conn(self, conn_string):
+        self.logger.debug(
+            ("Connection to {} died. "
+             "Removing the connection.").format(conn_string)
+        )
+        self.__conns.pop(conn_string, None)
+
 class Fireplace_nrepl:
     def __init__(self, wc):
         self.wc = wc
@@ -80,8 +87,12 @@ class CiderCompletionManager:
 
         wc = self.__connmanager.get_conn(conn_string)
 
+        def on_error(e):
+            self.__connmanager.remove_conn(conn_string)
+
         return cider_gather(self.__logger,
                             Fireplace_nrepl(wc),
                             complete_str,
                             connection.get("session"),
-                            ns)
+                            ns,
+                            on_error)


### PR DESCRIPTION
Fixes #14. I have this code running locally in my Neovim/deoplete/fireplace setup and it appears to do the trick.

Note that this only fixes the issue that I was experiencing with fireplace. Assuming the problem also crops up with acid, similar code will need to be added to acid.py, or better yet, the "remove the connection if a BrokenPipeError happens" bit could be factored out and used by both implementations. 