### PR TITLE
Change completion start to 2 for nvim

### DIFF
--- a/autoload/async_clj_omni/ncm2.vim
+++ b/autoload/async_clj_omni/ncm2.vim
@@ -17,7 +17,7 @@ function! async_clj_omni#ncm2#init()
         \ 'priority': 9,
         \ 'word_pattern': '[\w!$%&*+/:<=>?@\^_~\-\.#]+',
         \ 'complete_pattern': ['\.', '/'],
-        \ 'complete_length': 0,
+        \ 'complete_length': 2,
         \ 'matcher': 'none',
         \ 'scope': ['clojure'],
         \ 'on_complete': function('<SID>on_complete'),


### PR DESCRIPTION
The current `complete_length` of 0 is overwhelming and constantly bombarding the autocomplete with every possible suggestion in the namespace, even when your cursor is just chilling out as you think about what to write next. Setting it to 2 makes a bit more sense as a default option.